### PR TITLE
Fix missing install command

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -55,7 +55,7 @@ sed -i "s/#net.ipv4.ip_forward/net.ipv4.ip_forward/" /etc/sysctl.conf
 sysctl -p
 
 # Install iptables-persistent so that rules can persist across reboots
-apt-get -y iptables-persistent
+apt-get install -y iptables-persistent
 
 # Edit iptables rules to allow for forwarding
 iptables -t nat -A POSTROUTING -o tun+ -j MASQUERADE


### PR DESCRIPTION
Looks like a typo, the `apt-get` command was missing the `install` subcommand.