### PR TITLE
openvpn needs to accept dpkg for provisioner

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -55,6 +55,8 @@ sed -i "s/#net.ipv4.ip_forward/net.ipv4.ip_forward/" /etc/sysctl.conf
 sysctl -p
 
 # Install iptables-persistent so that rules can persist across reboots
+echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections
+echo iptables-persistent iptables-persistent/autosave_v6 boolean true | sudo debconf-set-selections
 apt-get install -y iptables-persistent
 
 # Edit iptables rules to allow for forwarding


### PR DESCRIPTION
debian configuration to set to accept iptables-persistent agreement 
Vagrant provisioner fix for hang
accept ipv4 and ipv6 agreements
