### PR TITLE
Newer AWS instances (C5) don't have eth0 devices. Handle postrouting correctly

### DIFF
--- a/interfaces.sh
+++ b/interfaces.sh
@@ -3,22 +3,19 @@
 DEVICES=$(ifconfig -s | grep -v "Iface\|lo\|tun0" | cut -d " " -f 1)
 NUMDEVICES=$(ifconfig -s | wc -l)
 VPNDEVICE=""
-ETH0=false
 
 # If we have an eth0 device, use that to maintain current functionality.
 if ifconfig -s | grep -q eth0
 then
-  ETH0=true
   export VPNDEVICE="eth0"
-fi
 
 # If we hit newer systemd/hypervisor combination, it won't be eth0, but there
 # will probably be only one obvious device to use: not the loop back, and not
 # the tunnel. Use it instead.
-if [ $NUMDEVICES -eq 4 ] && [ !$ETH0 ]
-then
+elif [ $NUMDEVICES -eq 3 ] 
+  then
   # no eth0 device, but only one option, use it.
-  export VPNDEVICE=$(ifconfig -s | tail -n 3 | grep -v "lo\|tun0" | cut -d " " -f 1)
+  export VPNDEVICE=$(ifconfig -s | tail -n 2 | cut -d " " -f 1 | grep -v "lo\|tun0")
 
 else
   # If we end up on a server that has multiple devices and no eth0, just ask.

--- a/interfaces.sh
+++ b/interfaces.sh
@@ -17,12 +17,12 @@ elif [ $NUMDEVICES -eq 3 ]
   # no eth0 device, but only one option, use it.
   export VPNDEVICE=$(ifconfig -s | tail -n 2 | cut -d " " -f 1 | grep -v "lo\|tun0")
 
+# If we end up on a server that has multiple devices and no eth0, just ask.
+# This is fairly common, Docker containers, wifi cards, dual nics, etc.
 else
-  # If we end up on a server that has multiple devices and no eth0, just ask.
-  # This is fairly common, Docker containers, wifi cards, dual nics, etc.
   echo "There are multiple network devices on this server:"
   echo ""
-  ifconfig -s | grep -v "Iface\|lo\|tun0" | cut -d " " -f 1
+  ifconfig -s | cut -d " " -f 1 | grep -v "Iface\|lo\|tun0"
   echo ""
   echo "Please type the name of the device you'd like to use"
   read VPNDEVICE

--- a/interfaces.sh
+++ b/interfaces.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+DEVICES=$(ifconfig -s | grep -v "Iface\|lo\|tun0" | cut -d " " -f 1)
+NUMDEVICES=$(ifconfig -s | wc -l)
+VPNDEVICE=""
+ETH0=false
+
+# If we have an eth0 device, use that to maintain current functionality.
+if ifconfig -s | grep -q eth0
+then
+  ETH0=true
+  export VPNDEVICE="eth0"
+fi
+
+# If we hit newer systemd/hypervisor combination, it won't be eth0, but there
+# will probably be only one obvious device to use: not the loop back, and not
+# the tunnel. Use it instead.
+if [ $NUMDEVICES -eq 4 ] && [ !$ETH0 ]
+then
+  # no eth0 device, but only one option, use it.
+  export VPNDEVICE=$(ifconfig -s | tail -n 3 | grep -v "lo\|tun0" | cut -d " " -f 1)
+
+else
+  # If we end up on a server that has multiple devices and no eth0, just ask.
+  # This is fairly common, Docker containers, wifi cards, dual nics, etc.
+  echo "There are multiple network devices on this server:"
+  echo ""
+  ifconfig -s | grep -v "Iface\|lo\|tun0" | cut -d " " -f 1
+  echo ""
+  echo "Please type the name of the device you'd like to use"
+  read VPNDEVICE
+
+  # Catch bad user input  
+  while ! echo $DEVICES | grep -q "${VPNDEVICE}"
+  do
+    echo "${VPNDEVICE} was not found in the list of devices. Please type the device name again"
+    read VPNDEVICE
+  done
+  export $VPNDEVICE
+
+fi

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -15,6 +15,7 @@ fi
 
 # Load config
 source ./config.sh
+source ./interfaces.sh
 
 # Install OpenVPN and expect
 apt-get -y install openvpn easy-rsa expect
@@ -64,7 +65,7 @@ apt-get install -y iptables-persistent
 
 # Edit iptables rules to allow for forwarding
 iptables -t nat -A POSTROUTING -o tun+ -j MASQUERADE
-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -o $VPNDEVICE -j MASQUERADE
 
 # Make iptables rules persistent across reboots
 iptables-save > /etc/iptables/rules.v4


### PR DESCRIPTION
Hello,

Super appreciate this project. Saved me a lot of work. Here's some changes that allow this to work on the new C5 AWS instances which don't have an eth0 networking device, and have an ensX device. Three cases are considered:

eth0 + X:
  - works the same as before

lo + single other interface:
  - Works without prompting the user

lo + multiple other interfaces:
  - Prompts the user to select from a list.

I tested the first two cases, on a t2 and a c5, respectively.

While I know that my script executes correctly in the third multi-interface case, I suspect this may result in only a partially working VPN, where some routes work but others don't. This is perhaps better than before as it might give a savvy user a place to start looking, but may confuse a less savvy user. I'm operating under the assumption that some functionality is better than none.