### PR TITLE
Reconfigured to use build-key-pass instead of build-key

### DIFF
--- a/build-key.sh
+++ b/build-key.sh
@@ -7,7 +7,25 @@
 
 set name [lindex $argv 0];
 
-spawn ./build-key $name
+# Get the password for the VPN account
+stty -echo
+send_user -- "VPN User Password: "
+expect_user -re "(.*)\n"
+send_user "\n"
+stty echo
+set pass $expect_out(1,string)
+
+# Confirm the password for the VPN account
+stty -echo
+send_user -- "Confirm VPN User Password: "
+expect_user -re "(.*)\n"
+send_user "\n"
+stty echo
+set confirm_pass $expect_out(1,string)
+
+spawn ./build-key-pass $name
+send -- "$pass\r"
+send -- "$confirm_pass\r"
 expect "Country Name"
 send "\n"
 expect "State or Province Name"


### PR DESCRIPTION
The "build-key" script creates a client configuration that has the key unencrypted in the file. This would allow anyone with the file to access the VPN with no further checks. I've converted this to use the "build-key-pass" script which prompts the user for a password to connect to the VPN.