### PR TITLE
fix: add mssfix 1280 for T-Mobile CGNAT compatibility

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -62,6 +62,7 @@ cp /usr/share/doc/openvpn/examples/sample-config-files/server.conf /etc/openvpn/
 sed -i "s/^;tls-auth ta.key.*$/tls-crypt ta.key 0/" /etc/openvpn/server/server.conf
 # sed -i "s/cipher AES-256-CBC/cipher AES-256-GCM\nauth SHA256/" /etc/openvpn/server/server.conf
 sed -i "s/dh dh2048.pem/;dh dh2048.pem\ndh none/" /etc/openvpn/server/server.conf
+sed -i "s/keepalive 10 120/keepalive 10 120\nmssfix 1280/" /etc/openvpn/server/server.conf
 # sed -i "s/;user openvpn/user openvpn/" /etc/openvpn/server/server.conf
 # sed -i "s/;group openvpn/group openvpn/" /etc/openvpn/server/server.conf
 


### PR DESCRIPTION
## Summary

- Adds `mssfix 1280` to the OpenVPN server config via `openvpn.sh`
- T-Mobile hotspot uses Carrier-Grade NAT (CGNAT) which adds packet overhead on top of VPN tunnel encapsulation, causing large TCP response packets to be silently dropped
- This manifests as: VPN connects successfully, TCP handshakes work, but HTTP responses never arrive (0 bytes received)
- `mssfix 1280` clamps the TCP MSS so fully-encapsulated packets fit within T-Mobile's effective path MTU

## Test plan

- [ ] Spin up a new VPN server using the bootstrap scripts
- [ ] Connect via T-Mobile hotspot and verify internal resources (e.g. Metabase) load correctly
- [ ] Verify VPN still works normally on standard WiFi connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)